### PR TITLE
Issue with windows paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,12 +65,7 @@ module.exports = function(options) {
 
 		// Getting of outputDirectory from path of the first file in the stream
 		if (!builderOptions.outputDirectory) {
-			//Replace windows slashes with unix slashes
-			file.path = file.path.replace(/\\/g, '/');
-
-			var outputMatch = file.path.match(/^(.*?)\/?([^/]*)\.([^/]*)$/);
-
-			builderOptions.outputDirectory = outputMatch[1];
+			builderOptions.outputDirectory = path.basename(file.path);
 
 			// Specify css path relative to the gulp config directory
 			if (builderOptions.outputCss) {

--- a/index.js
+++ b/index.js
@@ -65,6 +65,9 @@ module.exports = function(options) {
 
 		// Getting of outputDirectory from path of the first file in the stream
 		if (!builderOptions.outputDirectory) {
+			//Replace windows slashes with unix slashes
+			file.path = file.path.replace(/\\/g, '/');
+
 			var outputMatch = file.path.match(/^(.*?)\/?([^/]*)\.([^/]*)$/);
 
 			builderOptions.outputDirectory = outputMatch[1];

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function(options) {
 
 		// Getting of outputDirectory from path of the first file in the stream
 		if (!builderOptions.outputDirectory) {
-			builderOptions.outputDirectory = path.basename(file.path);
+			builderOptions.outputDirectory = path.basename(file.path, path.extname(file.path));
 
 			// Specify css path relative to the gulp config directory
 			if (builderOptions.outputCss) {


### PR DESCRIPTION
When running gulp-node-spritesheet on windows we discovered it was unable to parse the path to some images properly.  It appears to be occurring because the regex used to parse the path assumes unix-style slashes.  

I've replaced the regex and instead use node.path to parse out the filename.
